### PR TITLE
Chore: 배포 스크립트 이미지 이름 소문자 변환 처리 추가

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,7 +10,7 @@ if [ -z "$REGISTRY" ] || [ -z "$IMAGE_NAME" ] || [ -z "$IMAGE_TAG" ]; then
     exit 1
 fi
 
-TARGET_IMAGE="${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
+TARGET_IMAGE=$(echo "${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}" | tr '[:upper:]' '[:lower:]')
 
 echo "배포 시작: $TARGET_IMAGE (포트: $APP_PORT)"
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#50 

## 📝작업 내용

이미지 이름을 소문자로 변환하는 코드 추가했습니다.

기존 코드
```shell
TARGET_IMAGE="${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
```

변경된 코드
```shell
TARGET_IMAGE=$(echo "${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}" | tr '[:upper:]' '[:lower:]')
```

## 💬리뷰 요구사항(선택) 및 기타 참고사항

빠른 배포를 위해 승인 부탁드립니다!

## ✅ 체크리스트

- [x] 코드 점검 완료했습니다
- [x] 문서/주석 최신화 완료했습니다
