### PR TITLE
Fix: 쿠키 도메인 설정 에러 해결 #181

### DIFF
--- a/src/main/java/kr/co/amateurs/server/config/auth/CookieUtils.java
+++ b/src/main/java/kr/co/amateurs/server/config/auth/CookieUtils.java
@@ -25,33 +25,36 @@ public class CookieUtils {
     public void setAuthTokenCookie(HttpServletResponse response, TokenInfoDTO tokenInfoDTO) {
         log.debug("인증 토큰 쿠키 설정 시작");
 
-        Cookie accessTokenCookie = createSecureCookie(
+        String accessTokenCookie = buildCookieString(
                 ACCESS_TOKEN_COOKIE_NAME,
                 tokenInfoDTO.accessToken(),
                 Math.toIntExact(tokenInfoDTO.accessTokenExpiresIn() / 1000)
         );
-        response.addCookie(accessTokenCookie);
+        response.addHeader("Set-Cookie", accessTokenCookie);
 
-        // Refresh Token 쿠키 생성 (초 단위)
-        Cookie refreshTokenCookie = createSecureCookie(
+        String refreshTokenCookie = buildCookieString(
                 REFRESH_TOKEN_COOKIE_NAME,
                 tokenInfoDTO.refreshToken(),
                 Math.toIntExact(tokenInfoDTO.refreshTokenExpiresIn() / 1000)
         );
-        response.addCookie(refreshTokenCookie);
+        response.addHeader("Set-Cookie", refreshTokenCookie);
     }
 
-    private Cookie createSecureCookie(String name, String value, int maxAge) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setMaxAge(maxAge);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setSecure(secure);
+    private String buildCookieString(String name, String value, int maxAge) {
+        StringBuilder cookie = new StringBuilder();
+        cookie.append(name).append("=").append(value);
+        cookie.append("; Path=/; HttpOnly");
 
-        if (StringUtils.hasText(cookieDomain)) {
-            cookie.setDomain(cookieDomain);
+        if (secure) {
+            cookie.append("; Secure");
         }
 
-        return cookie;
+        if (StringUtils.hasText(cookieDomain)) {
+            cookie.append("; Domain=").append(cookieDomain);
+        }
+
+        cookie.append("; Max-Age=").append(maxAge);
+
+        return cookie.toString();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#181 

## 📝작업 내용

### 문제 상황
- 로그인 API 호출 시 쿠키 설정 단계에서 실패하여 전체 로그인 프로세스 중단
- 프론트엔드와 백엔드간 쿠키 공유 불가

### 해결 방법
- HttpServletResponse 직접 헤더 설정 방식으로 변경

## 💬리뷰 요구사항(선택) 및 기타 참고사항

> ex) 실행 시 yml 파일 필요합니다. (작성 시 지우기)


## ✅ 체크리스트

- [ ] 코드 점검 완료했습니다
- [ ] 문서/주석 최신화 완료했습니다
