### PR TITLE
Chore: JaCoCo 테스트 커버리지 추가 #203

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,13 +30,13 @@ jobs:
       - name: 코드 체크아웃
         uses: actions/checkout@v4
 
-      - name: JDK 17 설정
+      - name: JDK 17 세팅
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Gradle 캐시 설정
+      - name: Gradle 캐시 세팅
         uses: actions/cache@v4
         with:
           path: |
@@ -46,6 +46,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: jOOQ 캐시 세팅
+        uses: actions/cache@v4
+        with:
+          path: |
+            src/generated/
+            .gradle/jooq-docker/
+          key: jooq-${{ hashFiles('src/main/resources/db/migration/*.sql', 'build.gradle') }}
+          restore-keys: |
+            jooq-
+          fail-on-cache-miss: true
+
       - name: Docker 서비스 시작
         run: |
           sudo systemctl start docker
@@ -54,8 +65,8 @@ jobs:
       - name: Gradle 실행 권한 부여
         run: chmod +x gradlew
 
-      - name: jOOQ 클래스 생성
-        run: ./gradlew generateJooqClasses
+      - name: Docker Buildx 설정
+        uses: docker/setup-buildx-action@v3
 
       - name: GHCR 로그인
         uses: docker/login-action@v3
@@ -76,13 +87,15 @@ jobs:
 
       - name: Docker 이미지 빌드 & 푸시
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: 빌드 결과 설정
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,16 @@ jobs:
               - 'src/**'
               - 'build.gradle'
 
+  jooq:
+    name: jOOQ 세팅
+    needs: check-changes
+    uses: ./.github/workflows/jooq.yml
+    permissions:
+      contents: read
+
   test:
     name: 테스트 워크플로우
-    needs: check-changes
+    needs: jooq
     # if: needs.check-changes.outputs.should-run == 'true'
     uses: ./.github/workflows/test.yml
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
     permissions:
-      contents: read
+      contents: write
       checks: write
       pull-requests: write
       actions: read

--- a/.github/workflows/jooq.yml
+++ b/.github/workflows/jooq.yml
@@ -1,0 +1,79 @@
+name: jOOQ
+
+on:
+  workflow_call:
+    outputs:
+      cache-hit:
+        description: "jOOQ 캐시 히트 여부"
+        value: ${{ jobs.jooq.outputs.cache-hit }}
+      status:
+        description: "jOOQ 생성 실행 결과"
+        value: ${{ jobs.jooq.outputs.status }}
+
+jobs:
+  jooq:
+    name: jOOQ 클래스 생성
+    runs-on: ubuntu-latest
+
+    outputs:
+      cache-hit: ${{ steps.jooq-cache.outputs.cache-hit }}
+      status: ${{ steps.result.outputs.status }}
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: JDK 17 설정
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle 캐시 설정
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: jOOQ 캐시 확인
+        id: jooq-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            src/generated/
+            .gradle/jooq-docker/
+          key: jooq-${{ hashFiles('src/main/resources/db/migration/*.sql', 'build.gradle') }}
+          restore-keys: |
+            jooq-
+
+      - name: Docker 서비스 시작
+        if: steps.jooq-cache.outputs.cache-hit != 'true'
+        run: |
+          sudo systemctl start docker
+          docker --version
+
+      - name: Gradle 실행 권한 부여
+        if: steps.jooq-cache.outputs.cache-hit != 'true'
+        run: chmod +x gradlew
+
+      - name: jOOQ 클래스 생성
+        if: steps.jooq-cache.outputs.cache-hit != 'true'
+        id: jooq-generation
+        run: |
+          ./gradlew generateJooqClasses
+
+      - name: 생성 결과 설정
+        if: always()
+        id: result
+        run: |
+          if [ "${{ steps.jooq-cache.outputs.cache-hit }}" = "true" ]; then
+            echo "status=cached" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.jooq-generation.outcome }}" = "success" ]; then
+            echo "status=generated" >> $GITHUB_OUTPUT
+          else
+            echo "status=failed" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Gradle 테스트 실행 및 분석
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew test sonar --quiet
+        run: ./gradlew test
 
       - name: 테스트 커버리지 게시
         uses: irongut/CodeCoverageSummary@v1.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,21 +48,18 @@ jobs:
         run: chmod +x gradlew
 
       - name: Gradle 테스트 실행 및 분석
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew test
 
       - name: 테스트 커버리지 게시
-        uses: irongut/CodeCoverageSummary@v1.3.0
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.7.2
         with:
-          filename: build/reports/jacoco/test/jacocoTestReport.xml
-          badge: true
-          format: markdown
-          hide_branch_rate: false
-          hide_complexity: false
-          indicators: true
-          output: both
-          thresholds: '50 80'
+          paths: |
+            ${{ github.workspace }}/build/reports/jacoco/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "테스트 커버리지"
+          min-coverage-overall: 50
+          min-coverage-changed-files: 50
 
       - name: 테스트 결과 게시
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,11 +33,36 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: jOOQ 캐시 세팅
+        uses: actions/cache@v4
+        with:
+          path: |
+            src/generated/
+            .gradle/jooq-docker/
+          key: jooq-${{ hashFiles('src/main/resources/db/migration/*.sql', 'build.gradle') }}
+          restore-keys: |
+            jooq-
+          fail-on-cache-miss: true
+
       - name: Gradle 실행 권한 부여
         run: chmod +x gradlew
 
-      - name: Gradle 테스트 실행
-        run: ./gradlew test
+      - name: Gradle 테스트 실행 및 분석
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew test sonar --quiet
+
+      - name: 테스트 커버리지 게시
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: build/reports/jacoco/test/jacocoTestReport.xml
+          badge: true
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: false
+          indicators: true
+          output: both
+          thresholds: '50 80'
 
       - name: 테스트 결과 게시
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,11 @@ jobs:
   test:
     name: 테스트 실행
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: write
+      actions: read
 
     outputs:
       status: ${{ job.status }}
@@ -16,6 +21,9 @@ jobs:
     steps:
       - name: 코드 체크아웃
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: JDK 17 세팅
         uses: actions/setup-java@v4
@@ -50,8 +58,26 @@ jobs:
       - name: Gradle 테스트 실행 및 분석
         run: ./gradlew test
 
+      - name: 커버리지 뱃지 생성
+        id: jacoco-badge
+        uses: cicirello/jacoco-badge-generator@v2
+        with:
+          jacoco-csv-file: build/reports/jacoco/test/jacocoTestReport.csv
+          generate-branches-badge: true
+          generate-summary: true
+
+      - name: 커버리지 뱃지 커밋
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          if [[ `git status --porcelain` ]]; then
+            git config --global user.name 'kjyy08'
+            git config --global user.email 'kjyy08@users.noreply.github.com'
+            git add -A
+            git commit -m "Chore: JaCoCo coverage badge update"
+            git push
+          fi
+
       - name: 테스트 커버리지 게시
-        id: jacoco
         uses: madrapps/jacoco-report@v1.7.2
         with:
           paths: |
@@ -60,6 +86,7 @@ jobs:
           title: "테스트 커버리지"
           min-coverage-overall: 50
           min-coverage-changed-files: 50
+          skip-if-no-changes: true
 
       - name: 테스트 결과 게시
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -70,6 +97,6 @@ jobs:
           commit: ${{ github.sha }}
           comment_mode: always
           check_name: "테스트 결과"
-          comment_title: "${{ github.sha }} 테스트 결과"
+          comment_title: "테스트 결과"
           report_individual_runs: true
           compare_to_earlier_commit: true

--- a/build.gradle
+++ b/build.gradle
@@ -259,8 +259,6 @@ tasks.named('test') {
 			"-XX:+UseStringDeduplication",
 			"-XX:G1HeapRegionSize=16m"
 	]
-
-	maxParallelForks = 1
 }
 
 tasks.named('compileJava') {

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.0'
 	id 'io.spring.dependency-management' version '1.1.7'
-
 	id 'dev.monosoul.jooq-docker' version '6.1.9'
+	id 'jacoco'
 }
 
 group = 'kr.co.amateurs'
@@ -66,6 +66,11 @@ jooq {
     }
 }
 
+jacoco {
+	toolVersion = "0.8.13"
+	reportsDirectory = layout.buildDirectory.dir("reports/jacoco")
+}
+
 tasks {
     generateJooqClasses {
         schemas.set(["amateurs_db"])
@@ -100,6 +105,68 @@ tasks {
         }
     }
 }
+
+jacocoTestReport {
+	dependsOn test
+
+	reports {
+		xml.required = true
+		html.required = true
+		csv.required = false
+	}
+
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: [
+					'**/generated/**',
+
+					'**/config/**',
+					'**/domain/**',
+					'**/exception/**',
+					'**/handler/**',
+					'**/repository/**',
+					'**/utils/**',
+
+					'**/*Application.*',
+			])
+		}))
+	}
+}
+
+jacocoTestCoverageVerification {
+	dependsOn jacocoTestReport
+
+	violationRules {
+		rule {
+			limit {
+				counter = 'INSTRUCTION'
+				value = 'COVEREDRATIO'
+				minimum = 0.50
+			}
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.50
+			}
+		}
+
+		rule {
+			element = 'CLASS'
+			limit {
+				counter = 'INSTRUCTION'
+				value = 'COVEREDRATIO'
+				minimum = 0.50
+			}
+
+			excludes = [
+					'*.Application',
+					'*.Config*',
+					'*.Configuration*'
+			]
+		}
+	}
+}
+
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -175,8 +242,25 @@ dependencies {
 	testImplementation 'org.awaitility:awaitility:4.2.0'
 }
 
+tasks.named('check') {
+	dependsOn jacocoTestCoverageVerification
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy(jacocoTestReport)
+
+	minHeapSize = "1g"
+	maxHeapSize = "4g"
+
+	jvmArgs = [
+			"-XX:MaxMetaspaceSize=1g",
+			"-XX:+UseG1GC",
+			"-XX:+UseStringDeduplication",
+			"-XX:G1HeapRegionSize=16m"
+	]
+
+	maxParallelForks = 1
 }
 
 tasks.named('compileJava') {

--- a/build.gradle
+++ b/build.gradle
@@ -263,9 +263,14 @@ tasks.named('test') {
 
 tasks.named('compileJava') {
 	options.encoding = 'UTF-8'
+	options.compilerArgs += ['-Alombok.addLombokGeneratedAnnotation=true']
 	if (!System.getenv('DOCKER_BUILD')) {
 		dependsOn('generateJooqClasses')
 	}
+}
+
+tasks.named('compileTestJava') {
+	options.compilerArgs += ['-Alombok.addLombokGeneratedAnnotation=true']
 }
 
 clean {

--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ jacocoTestReport {
 	reports {
 		xml.required = true
 		html.required = true
-		csv.required = false
+		csv.required = true
 	}
 
 	afterEvaluate {
@@ -263,14 +263,9 @@ tasks.named('test') {
 
 tasks.named('compileJava') {
 	options.encoding = 'UTF-8'
-	options.compilerArgs += ['-Alombok.addLombokGeneratedAnnotation=true']
 	if (!System.getenv('DOCKER_BUILD')) {
 		dependsOn('generateJooqClasses')
 	}
-}
-
-tasks.named('compileTestJava') {
-	options.compilerArgs += ['-Alombok.addLombokGeneratedAnnotation=true']
 }
 
 clean {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.daemon=false
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configureondemand=true
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
## #️⃣연관된 이슈

#203 

## 📝작업 내용

- `build.gradle` 수정
- `test.yml`: 테스트 커버리지 게시 스텝 추가
  - 변경점이 있어야 댓글로 추가됩니다.
  - 커버리지 뱃지 생성 포함
    - `main` 브랜치 병합 시에 `.github/badges/` 경로에 생성됩니다.
- jOOQ 클래스 생성 workflow 추가
- 도커 이미지, jOOQ 캐시 세팅 추가
- 테스트 결과 Actions 방식 변경
  - 기존: 추가 커밋 시 매번 새로 댓글 추가
  - 변경: 추가 커밋 시 기존 댓글을 수정

## 💬리뷰 요구사항(선택) 및 기타 참고사항

<img width="1228" height="24" alt="image" src="https://github.com/user-attachments/assets/e898b111-ab80-4210-8a80-7e5adb05f521" />

생각보다 커버리지가 그리 높지는 않네요.
테스트 커버리지 측정은 저희 테스트 방식에 맞게 컨트롤러, 서비스 중심으로 측정 돌렸습니다.
(config, domain, repository 같은 클래스는 제외)

## ✅ 체크리스트

- [x] 코드 점검 완료했습니다
- [x] 문서/주석 최신화 완료했습니다
