### PR TITLE
Chore: OpenTelemetry + Tempo 분산 트레이싱 구축 #229

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,13 +80,12 @@ jobs:
       - name: 테스트 커버리지 게시
         uses: madrapps/jacoco-report@v1.7.2
         with:
-          paths: |
-            ${{ github.workspace }}/build/reports/jacoco/jacocoTestReport.xml
+          paths: build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "테스트 커버리지"
           min-coverage-overall: 50
           min-coverage-changed-files: 50
-          skip-if-no-changes: true
+          update-comment: true
 
       - name: 테스트 결과 게시
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/build.gradle
+++ b/build.gradle
@@ -180,6 +180,7 @@ dependencies {
 	// OpenTelemetry 의존성
 	implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.11.0')
 	implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter'
+	implementation 'io.micrometer:micrometer-registry-otlp'
 
 	// JWT 관련 의존성
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
+	// OpenTelemetry 의존성
+	implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.11.0')
+	implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter'
+
 	// JWT 관련 의존성
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/docker/loki/loki-config.yml
+++ b/docker/loki/loki-config.yml
@@ -31,6 +31,13 @@ schema_config:
       index:
         prefix: index_
         period: 24h
+    - from: 2025-07-13
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
 
 limits_config:
   retention_period: 168h
@@ -40,7 +47,7 @@ limits_config:
   max_query_parallelism: 32
   reject_old_samples: true
   reject_old_samples_max_age: 168h
-  allow_structured_metadata: false
+  allow_structured_metadata: true
 
 compactor:
   working_directory: /loki/boltdb-shipper-compactor

--- a/docker/otel-collector/docker-compose.yml
+++ b/docker/otel-collector/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: otel-collector
+    ports:
+      - "4319:4318"
+      - "8888:8888"
+      - "8889:8889"
+    volumes:
+      - ./otel-collector-config.yml:/etc/otelcol-contrib/otel-collector-config.yml:ro
+    command:
+      - '--config=/etc/otelcol-contrib/otel-collector-config.yml'
+    restart: unless-stopped
+    networks:
+      - monitoring
+
+networks:
+  monitoring:
+    external: true

--- a/docker/otel-collector/otel-collector-config.yml
+++ b/docker/otel-collector/otel-collector-config.yml
@@ -1,0 +1,49 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 1s
+    send_batch_size: 1024
+    send_batch_max_size: 2048
+
+exporters:
+  otlphttp/tempo:
+    endpoint: http://tempo:4318
+    tls:
+      insecure: true
+  
+  otlphttp/prometheus:
+    endpoint: http://prometheus:9090/api/v1/otlp/v1/metrics
+    tls:
+      insecure: true
+  
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp/v1/logs
+    tls:
+      insecure: true
+
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    resource_to_telemetry_conversion:
+      enabled: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/tempo]
+    
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/prometheus, prometheus]
+    
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/loki]

--- a/docker/otel-collector/otel-collector-config.yml
+++ b/docker/otel-collector/otel-collector-config.yml
@@ -16,20 +16,15 @@ exporters:
     tls:
       insecure: true
   
-  otlphttp/prometheus:
-    endpoint: http://prometheus:9090/api/v1/otlp/v1/metrics
-    tls:
-      insecure: true
-  
-  otlphttp/loki:
-    endpoint: http://loki:3100/otlp/v1/logs
-    tls:
-      insecure: true
-
   prometheus:
     endpoint: 0.0.0.0:8889
     resource_to_telemetry_conversion:
       enabled: true
+
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
+    tls:
+      insecure: true
 
 service:
   pipelines:
@@ -41,7 +36,7 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlphttp/prometheus, prometheus]
+      exporters: [prometheus]
     
     logs:
       receivers: [otlp]

--- a/docker/prometheus/docker-compose.yml
+++ b/docker/prometheus/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - '--web.enable-lifecycle'
       - '--storage.tsdb.path=/prometheus'
       - '--storage.tsdb.retention.time=3d'
+      - '--web.enable-otlp-receiver'
     deploy:
       resources:
         limits:

--- a/docker/prometheus/docker-compose.yml
+++ b/docker/prometheus/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - '--web.enable-lifecycle'
       - '--storage.tsdb.path=/prometheus'
       - '--storage.tsdb.retention.time=3d'
-      - '--web.enable-otlp-receiver'
+      - '--enable-feature=otlp-write-receiver'
     deploy:
       resources:
         limits:

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -32,20 +32,3 @@ scrape_configs:
       - source_labels: [__address__]
         target_label: server_type
         replacement: 'main'
-
-  - job_name: 'spring-boot-app'
-    static_configs:
-      - targets: ['your-domain.co.kr:443']
-    scheme: https
-    metrics_path: '/actuator/prometheus'
-    scrape_interval: 30s
-    scrape_timeout: 20s
-    tls_config:
-      insecure_skip_verify: false
-    relabel_configs:
-      - source_labels: [__address__]
-        target_label: application
-        replacement: 'spring-boot-app'
-      - source_labels: [__address__]
-        target_label: environment
-        replacement: 'production'

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -8,6 +8,11 @@ scrape_configs:
       - targets: ['localhost:9090']
     scrape_interval: 30s
 
+  - job_name: 'otel-collector'
+    static_configs:
+      - targets: ['otel-collector:8889']
+    scrape_interval: 30s
+
   - job_name: 'monitoring-server-node'
     static_configs:
       - targets: ['node-exporter:9100']

--- a/docker/tempo/docker-compose.yml
+++ b/docker/tempo/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  tempo:
+    image: grafana/tempo:latest
+    container_name: tempo
+    restart: unless-stopped
+    command:
+      - "-config.file=/etc/tempo.yaml"
+    volumes:
+      - ./tempo-config.yml:/etc/tempo.yaml:ro
+      - tempo-data:/var/tempo:rw
+    ports:
+      - "3200:3200"
+      - "4318:4318"
+    networks:
+      - monitoring
+    environment:
+      - TEMPO_DATA_PATH=/var/tempo
+
+networks:
+  monitoring:
+    external: true
+
+volumes:
+  tempo-data:

--- a/docker/tempo/tempo-config.yml
+++ b/docker/tempo/tempo-config.yml
@@ -33,8 +33,14 @@ metrics_generator:
     remote_write:
       - url: http://prometheus:9090/api/v1/write
         send_exemplars: true
+  processor:
+    local_blocks:
+      flush_to_storage: true
+  traces:
+    wal:
+      path: /var/tempo/generator/traces_wal
 
 overrides:
   defaults:
     metrics_generator:
-      processors: [service-graphs, span-metrics]
+      processors: [service-graphs, span-metrics, local-blocks]

--- a/docker/tempo/tempo-config.yml
+++ b/docker/tempo/tempo-config.yml
@@ -1,0 +1,40 @@
+stream_over_http_enabled: true
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  trace_idle_period: 10s
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 168h
+    compaction_window: 1h
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks
+
+metrics_generator:
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics]

--- a/src/main/java/kr/co/amateurs/server/config/AsyncConfig.java
+++ b/src/main/java/kr/co/amateurs/server/config/AsyncConfig.java
@@ -1,0 +1,37 @@
+package kr.co.amateurs.server.config;
+
+import io.opentelemetry.context.Context;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean
+    @Primary
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(8);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("otel-async-");
+        executor.setTaskDecorator(new OpenTelemetryTaskDecorator());
+        executor.initialize();
+        return executor;
+    }
+
+    private static class OpenTelemetryTaskDecorator implements TaskDecorator {
+        @Override
+        public Runnable decorate(Runnable runnable) {
+            Context context = Context.current();
+            return context.wrap(runnable);
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -101,33 +101,13 @@ cloud:
       domain: ${CLOUD_FRONT_DOMAIN_NAME}
 
 management:
-  health:
-    mongo:
-      enabled: false # TODO: MongoDB Health Check 비활성화, 추후 활성화 필요
-
   endpoints:
     web:
       exposure:
-        include: health,info,prometheus,metrics
+        include: health,info
   endpoint:
-    health:
-      show-details: always # nginx에서 ip 제한 처리
     info:
       access: read_only
-    prometheus:
-      access: read_only
-    metrics:
-      access: read_only
-
-  metrics:
-    tags:
-      application: ${spring.application.name}
-      version: '@project.version@'
-  prometheus:
-    metrics:
-      export:
-        enabled: true
-        step: 30s
 
 logging:
   level:
@@ -135,13 +115,6 @@ logging:
     org.springframework: INFO
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: DEBUG
-  file:
-    name: /var/log/spring-boot/application.log
-  logback:
-    rollingpolicy:
-      max-file-size: 100MB
-      max-history: 7
-      total-size-cap: 1GB
 
 oauth:
   success-redirect-url: ${OAUTH_SUCCESS_REDIRECT_URL}
@@ -154,3 +127,13 @@ verification:
   service:
     url: http://localhost:5000
     endpoint: /verify
+
+otel:
+  service:
+    name: amateurs-api-server
+  traces:
+    exporter: console
+  metrics:
+    exporter: none
+  logs:
+    exporter: none

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -111,8 +111,17 @@ swagger:
   server:
     url: ${SERVER_URL}
 
-
 verification:
   service:
     url: ${VERIFICATION_SERVICE_URL}
     endpoint: /verify
+
+otel:
+  service:
+    name: amateurs-api-server
+  traces:
+    exporter: console
+  metrics:
+    exporter: none
+  logs:
+    exporter: none

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -111,7 +111,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health,info,prometheus,metrics
   endpoint:
     info:
       access: read_only
@@ -144,6 +144,10 @@ otel:
     exporter: otlp
   logs:
     exporter: otlp
+  instrumentation:
+    micrometer:
+      enabled: true
+
   exporter:
     otlp:
       endpoint: ${OTEL_COLLECTOR_URL}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -139,7 +139,7 @@ otel:
   traces:
     exporter: otlp
     sampler: parentbased_traceidratio
-    sampler.arg: 0.1
+    sampler.arg: 1.0
   metrics:
     exporter: otlp
   logs:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -111,35 +111,15 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,prometheus,metrics
+        include: health,info
   endpoint:
     info:
       access: read_only
-    prometheus:
-      access: read_only
-    metrics:
-      access: read_only
-  metrics:
-    tags:
-      application: ${spring.application.name}
-      version: '@project.version@'
-  prometheus:
-    metrics:
-      export:
-        enabled: true
-        step: 30s
 
 logging:
   level:
     root: info
     org.springframework: info
-  file:
-    name: /var/log/spring-boot/application.log
-  logback:
-    rollingpolicy:
-      max-file-size: 100MB
-      max-history: 7
-      total-size-cap: 1GB
 
 oauth:
   success-redirect-url: ${OAUTH_SUCCESS_REDIRECT_URL}
@@ -152,3 +132,20 @@ verification:
   service:
     url: ${VERIFICATION_SERVICE_URL}
     endpoint: /verify
+
+otel:
+  service:
+    name: amateurs-api-server
+  traces:
+    exporter: otlp
+    sampler: parentbased_traceidratio
+    sampler.arg: 0.1
+  metrics:
+    exporter: otlp
+  logs:
+    exporter: otlp
+  exporter:
+    otlp:
+      endpoint: ${OTEL_COLLECTOR_URL}
+      compression: gzip
+      timeout: 10s


### PR DESCRIPTION
## #️⃣연관된 이슈
#229 

## 📝작업 내용
**OpenTelemetry Collector 기반 LGTM 스택 구축**

- **OTel Collector 추가**: 중앙 집중식 텔레메트리 데이터 처리
  - `docker/otel-collector/` 디렉토리 및 설정 파일 생성
  - HTTP OTLP 수신기 (포트 4319) 설정
  - Tempo, Prometheus, Loki로 데이터 라우팅

- **Spring Boot 설정 개선**: 
  - 기존 Prometheus/로그 중복 설정 제거
  - OpenTelemetry 통합 설정으로 변경
  - 단일 OTLP 엔드포인트로 모든 텔레메트리 데이터 전송

- **백엔드 시스템 OTLP 지원 활성화**:
  - Prometheus: `--web.enable-otlp-receiver` 플래그 추가
  - Loki: 스키마 v13 추가로 구조화된 메타데이터 지원
  - Tempo: 기존 OTLP 지원 유지

- **분산 추적 기능 구현**:
  - 로그에 TraceId 자동 포함
  - 트레이스-로그-메트릭스 간 상관관계 추적 가능
  - Grafana에서 통합 관찰 가능성 제공

## 💬리뷰 요구사항(선택) 및 기타 참고사항

### 📊 LGTM 스택 구조도
```mermaid
graph TB
    subgraph "메인 EC2"
        SB[Spring Boot App]
    end
    
    subgraph "DevOps 인스턴스"
        OC[OpenTelemetry Collector<br/>:4319]
        
        subgraph "LGTM Stack"
            L[Loki<br/>로그 저장]
            G[Grafana<br/>시각화]
            T[Tempo<br/>분산 추적]
            M[Prometheus<br/>메트릭스]
        end
    end
    
    SB -->|OTLP| OC
    OC -->|트레이스| T
    OC -->|메트릭스| M
    OC -->|로그+TraceId| L
    
    G --> T
    G --> M
    G --> L
    
    style SB fill:#e1f5fe
    style OC fill:#f3e5f5
    style L fill:#e8f5e8
    style T fill:#fff3e0
    style M fill:#ffebee
    style G fill:#f1f8e9
```

### 🔄 데이터 흐름 변화
**기존**:
- Spring Boot → `/actuator/prometheus` → Prometheus (스크래핑)
- Spring Boot → 로그 파일 → Promtail → Loki
- 분산 추적 없음

**변경 후**:
- Spring Boot → OTel Collector → Tempo/Prometheus/Loki (OTLP)
- **모든 데이터에 TraceId 포함** → 분산 추적 가능

### ⚠️ 분산 추적 제한사항

- 자동 추적: HTTP 요청, JDBC, JPA, Redis 등
- 수동 계측 필요: WebSocket 메시지, CompletableFuture 등 비동기 작업
- 현재 적용 범위: RESTful API 및 동기 처리 로직에 한정

## ✅ 체크리스트
- [x] 코드 점검 완료했습니다
- [x] 문서/주석 최신화 완료했습니다