### PR TITLE
Fix : 토큰 재발급 API 쿠키 기반으로 수정 #232

### DIFF
--- a/src/main/java/kr/co/amateurs/server/controller/auth/AuthController.java
+++ b/src/main/java/kr/co/amateurs/server/controller/auth/AuthController.java
@@ -2,6 +2,7 @@ package kr.co.amateurs.server.controller.auth;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import kr.co.amateurs.server.domain.dto.auth.*;
@@ -57,9 +58,9 @@ public class AuthController {
 
     @PostMapping("/reissue")
     @Operation(summary = "토큰 재발급", description = "리프레시 토큰을 이용하여 새로운 액세스 토큰을 발급합니다")
-    public ResponseEntity<TokenReissueResponseDTO> reissueToken(@Valid @RequestBody TokenReissueRequestDTO request) {
-        TokenReissueResponseDTO response = authService.reissueToken(request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<TokenReissueResponseDTO> reissueToken(HttpServletRequest request, HttpServletResponse response) {
+        TokenReissueResponseDTO tokenResponse = authService.reissueToken(request, response);
+        return ResponseEntity.ok(tokenResponse);
     }
 
     @PostMapping("/logout")

--- a/src/main/java/kr/co/amateurs/server/domain/dto/user/UserProfileResponseDTO.java
+++ b/src/main/java/kr/co/amateurs/server/domain/dto/user/UserProfileResponseDTO.java
@@ -5,6 +5,7 @@ import kr.co.amateurs.server.domain.entity.post.enums.DevCourseTrack;
 import kr.co.amateurs.server.domain.entity.topic.UserTopic;
 import kr.co.amateurs.server.domain.entity.user.User;
 import kr.co.amateurs.server.domain.entity.user.enums.ProviderType;
+import kr.co.amateurs.server.domain.entity.user.enums.Role;
 import kr.co.amateurs.server.domain.entity.user.enums.Topic;
 import lombok.Builder;
 
@@ -24,6 +25,9 @@ public record UserProfileResponseDTO(
 
         @Schema(description = "이름")
         String name,
+
+        @Schema(description = "사용자 권한")
+        Role role,
 
         @Schema(description = "프로필 이미지 URL")
         String imageUrl,
@@ -47,6 +51,7 @@ public record UserProfileResponseDTO(
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .name(user.getName())
+                .role(user.getRole())
                 .imageUrl(user.getImageUrl())
                 .devcourseName(user.getDevcourseName())
                 .devcourseBatch(user.getDevcourseBatch())

--- a/src/test/java/kr/co/amateurs/server/service/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/amateurs/server/service/auth/AuthServiceTest.java
@@ -249,53 +249,6 @@ public class AuthServiceTest {
     }
 
     @Test
-    void 유효한_리프레시_토큰으로_토큰_재발급_시_새로운_액새스_토큰을_반환한다() throws InterruptedException {
-        // given
-        SignupRequestDTO signupRequest = UserTestFixture.createUniqueSignupRequest();
-        authService.signup(signupRequest);
-
-        LoginRequestDTO loginRequest = LoginRequestDTO.builder()
-                .email(signupRequest.email())
-                .password(signupRequest.password())
-                .build();
-
-        LoginResponseDTO loginResponse = authService.login(loginRequest);
-        Thread.sleep(1000);
-
-        TokenReissueRequestDTO reissueRequest = new TokenReissueRequestDTO(loginResponse.refreshToken());
-
-        // when
-        TokenReissueResponseDTO response = authService.reissueToken(reissueRequest);
-
-        // then
-        assertThat(response.accessToken()).isNotNull();
-        assertThat(response.tokenType()).isEqualTo("Bearer");
-        assertThat(response.expiresIn()).isEqualTo(TokenTestFixture.ACCESS_TOKEN_EXPIRATION);
-        assertThat(response.accessToken()).isNotEqualTo(loginResponse.accessToken());
-    }
-
-    @Test
-    void 유효하지_않은_리프레시_토큰으로_재발급_시_예외가_발생한다() {
-        // given
-        TokenReissueRequestDTO invalidRequest = new TokenReissueRequestDTO("invalid.token.here");
-
-        // when & then
-        assertThatThrownBy(() -> authService.reissueToken(invalidRequest))
-                .isInstanceOf(CustomException.class);
-    }
-
-    @Test
-    void 존재하지_않는_사용자의_리프레시_토큰으로_재발급_시_예외가_발생한다() {
-        // given
-        String fakeRefreshToken = jwtProvider.generateRefreshToken("nonexistent@test.com");
-        TokenReissueRequestDTO request = new TokenReissueRequestDTO(fakeRefreshToken);
-
-        // when & then
-        assertThatThrownBy(() -> authService.reissueToken(request))
-                .isInstanceOf(CustomException.class);
-    }
-
-    @Test
     void 정상적인_로그아웃_시_리프레시_토큰이_삭제된다() {
         // given
         SignupRequestDTO signupRequest = UserTestFixture.createUniqueSignupRequest();


### PR DESCRIPTION
## #️⃣연관된 이슈

#232 

## 📝작업 내용

토큰 재발급 API를 완전히 쿠키 기반으로 변경하여 프론트엔드 400 에러를 해결했습니다

### 🔧 주요 변경사항
- **AuthController**: `@RequestBody TokenReissueRequestDTO` 제거, `HttpServletRequest` 파라미터 추가
- **AuthService**: `getRefreshTokenFromCookie()` 메서드 구현으로 쿠키에서 refreshToken 읽기
- **테스트 코드**: Controller 레벨 쿠키 기반 테스트로 변경 (REST Assured 활용)

### 🚨 해결된 문제
- 프론트엔드에서 "리프레시 토큰은 필수입니다" 400 에러 해결
- HttpOnly 쿠키 보안성 유지하면서 정상 동작 구현
- 토큰 재발급 후 자동 인터셉터 동작 확인

## 💬리뷰 요구사항(선택) 및 기타 참고사항

토큰 재발급 로직이 완전히 쿠키 기반으로 변경되었습니다 기존 RequestBody 방식과 호환되지 않으니 참고해주세요

## ✅ 체크리스트

- [ ] 코드 점검 완료했습니다
- [ ] 문서/주석 최신화 완료했습니다
