### PR TITLE
Feat: 유저 정보 모달에 필요한 정보 전달용 API 추가

### DIFF
--- a/src/main/java/kr/co/amateurs/server/controller/user/UserController.java
+++ b/src/main/java/kr/co/amateurs/server/controller/user/UserController.java
@@ -98,4 +98,12 @@ public class UserController {
         PageResponseDTO<PostResponseDTO> likePostList = postService.getMyPostList(paginationParam);
         return ResponseEntity.ok(likePostList);
     }
+
+    @GetMapping("/{nickname}/info")
+    @Operation(summary = "유저 모달 정보", description = "유저 정보 모달에 포함될 요약 정보를 가져옵니다.")
+    public ResponseEntity<UserModalInfoResponseDTO> getUserModalInfo(
+            @PathVariable String nickname){
+        UserModalInfoResponseDTO response = userService.getUserModalInfo(nickname);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/kr/co/amateurs/server/domain/dto/user/UserModalInfoResponseDTO.java
+++ b/src/main/java/kr/co/amateurs/server/domain/dto/user/UserModalInfoResponseDTO.java
@@ -1,0 +1,13 @@
+package kr.co.amateurs.server.domain.dto.user;
+
+import kr.co.amateurs.server.domain.entity.post.enums.DevCourseTrack;
+
+public record UserModalInfoResponseDTO(
+        Long userId,
+        String nickname,
+        String imageUrl,
+        DevCourseTrack devCourseName,
+        String devCourseBatch,
+        boolean isFollowing
+) {
+}

--- a/src/main/java/kr/co/amateurs/server/repository/follow/FollowRepository.java
+++ b/src/main/java/kr/co/amateurs/server/repository/follow/FollowRepository.java
@@ -1,6 +1,5 @@
 package kr.co.amateurs.server.repository.follow;
 
-import kr.co.amateurs.server.domain.dto.follow.FollowResponseDTO;
 import kr.co.amateurs.server.domain.entity.follow.Follow;
 import kr.co.amateurs.server.domain.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +12,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     List<Follow> findByFromUser(User fromUser);
 
     void deleteByToUserAndFromUser(User toUser, User fromUser);
+
+    boolean existsByFromUserAndToUser(User fromUser, User toUser);
 }

--- a/src/main/java/kr/co/amateurs/server/repository/user/UserRepository.java
+++ b/src/main/java/kr/co/amateurs/server/repository/user/UserRepository.java
@@ -1,5 +1,6 @@
 package kr.co.amateurs.server.repository.user;
 
+import kr.co.amateurs.server.domain.dto.user.UserModalInfoResponseDTO;
 import kr.co.amateurs.server.domain.entity.user.User;
 import kr.co.amateurs.server.domain.entity.user.enums.Role;
 import kr.co.amateurs.server.domain.entity.user.enums.ProviderType;
@@ -20,7 +21,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByProviderIdAndProviderType(String providerId, ProviderType providerType);
 
-    Optional<User> findByNickname(String testUser);
+    User findByNickname(String nickname);
 
     @Query("SELECT ut.topic FROM UserTopic ut WHERE ut.user.id = :userId")
     List<Topic> findTopicDisplayNamesByUserId(@Param("userId") Long userId);

--- a/src/main/java/kr/co/amateurs/server/service/UserService.java
+++ b/src/main/java/kr/co/amateurs/server/service/UserService.java
@@ -9,6 +9,7 @@ import kr.co.amateurs.server.domain.entity.user.enums.ProviderType;
 import kr.co.amateurs.server.domain.entity.user.enums.Role;
 import kr.co.amateurs.server.domain.entity.user.enums.Topic;
 import kr.co.amateurs.server.exception.CustomException;
+import kr.co.amateurs.server.repository.follow.FollowRepository;
 import kr.co.amateurs.server.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -30,6 +31,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final FollowRepository followRepository;
 
     public void validateEmailDuplicate(String email) {
         if (userRepository.existsByEmail(email)) {
@@ -251,5 +253,18 @@ public class UserService {
     public void changeUserRole(User user, Role newRole) {
         user.changeRole(newRole);
         userRepository.save(user);
+    }
+
+    public UserModalInfoResponseDTO getUserModalInfo(String nickname) {
+        User currentUser = getCurrentLoginUser();
+        User targetUser = userRepository.findByNickname(nickname);
+        boolean isFollowing = followRepository.existsByFromUserAndToUser(currentUser, targetUser);
+        return new UserModalInfoResponseDTO(
+                targetUser.getId(),
+                targetUser.getNickname(),
+                targetUser.getImageUrl(),
+                targetUser.getDevcourseName(),
+                targetUser.getDevcourseBatch(),
+                isFollowing);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호 (작성 시 지우기)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) - (작성 시 지우기)

유저 요약 정보 모달(팔로우, DM 등 포함)에 필요한 정보를 전달하는 API 추가

## 💬리뷰 요구사항(선택) 및 기타 참고사항

> ex) 실행 시 yml 파일 필요합니다. (작성 시 지우기)


## ✅ 체크리스트

- [ ] 코드 점검 완료했습니다
- [ ] 문서/주석 최신화 완료했습니다
