### PR TITLE
Fix: 배포 수강생 인증 안되는 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,7 @@ jacocoTestReport {
 					'**/utils/**',
 
 					'**/*Application.*',
+					'**/controller/ai/AiDevController.*',
 			])
 		}))
 	}

--- a/src/main/java/kr/co/amateurs/server/annotation/alarmtrigger/creator/CommentAlarmCreator.java
+++ b/src/main/java/kr/co/amateurs/server/annotation/alarmtrigger/creator/CommentAlarmCreator.java
@@ -127,7 +127,7 @@ public class CommentAlarmCreator implements AlarmCreator {
     /**
      * 댓글 알람의 내용 메시지를 생성합니다.
      *
-     * @param commentAuthorNickname 댓글 작성자의 닉네임
+     * @param commentAuthorNickname 댓글 작성자의 닉ai_profiles네임
      * @param post                  댓글이 달린 게시글
      * @return 알람 내용 메시지
      */

--- a/src/main/java/kr/co/amateurs/server/annotation/alarmtrigger/creator/CommentAlarmCreator.java
+++ b/src/main/java/kr/co/amateurs/server/annotation/alarmtrigger/creator/CommentAlarmCreator.java
@@ -127,7 +127,7 @@ public class CommentAlarmCreator implements AlarmCreator {
     /**
      * 댓글 알람의 내용 메시지를 생성합니다.
      *
-     * @param commentAuthorNickname 댓글 작성자의 닉ai_profiles네임
+     * @param commentAuthorNickname 댓글 작성자의 닉네임
      * @param post                  댓글이 달린 게시글
      * @return 알람 내용 메시지
      */

--- a/src/main/java/kr/co/amateurs/server/config/auth/http/AiAdminAuthorizeHttpRequestsConfig.java
+++ b/src/main/java/kr/co/amateurs/server/config/auth/http/AiAdminAuthorizeHttpRequestsConfig.java
@@ -1,0 +1,14 @@
+package kr.co.amateurs.server.config.auth.http;
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AiAdminAuthorizeHttpRequestsConfig implements CustomAuthorizeHttpRequestsConfigurer {
+    @Override
+    public void configure(AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth) {
+        auth
+                .requestMatchers("/api/v1/ai/dev/**").hasRole("ADMIN");
+    }
+}

--- a/src/main/java/kr/co/amateurs/server/controller/ai/AiAdminController.java
+++ b/src/main/java/kr/co/amateurs/server/controller/ai/AiAdminController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.co.amateurs.server.config.jwt.CustomUserDetails;
 import kr.co.amateurs.server.domain.dto.ai.AiProfileResponse;
 import kr.co.amateurs.server.domain.dto.ai.PostRecommendationResponse;
-import kr.co.amateurs.server.domain.entity.ai.AiProfile;
 import kr.co.amateurs.server.service.ai.AiProfileService;
 import kr.co.amateurs.server.service.ai.PostEmbeddingManageService;
 import kr.co.amateurs.server.service.ai.PostEmbeddingService;
@@ -29,9 +28,8 @@ import java.util.List;
 @RequestMapping("/api/v1/ai/dev")
 @RequiredArgsConstructor
 @Slf4j
-@Tag(name = "AI 개발", description = "AI 관련 개발용 컨트롤러")
-@Profile({"local", "dev"})
-public class AiDevController {
+@Tag(name = "[ADMIN] AI 컨트롤러", description = "AI 관리자 컨트롤러")
+public class AiAdminController {
 
     private final AiProfileService aiProfileService;
     private final PostRecommendService postRecommendService;
@@ -123,7 +121,7 @@ public class AiDevController {
 
 
     @PostMapping("/embeddings/initialize")
-    @Operation(summary = "게시글 임베딩 초기화", description = "모든 게시글의 임베딩을 생성하고 저장합니다")
+    @Operation(summary = "게시글 임베딩 초기화", description = "모든 게시글의 임베딩을 초기화하고 다시 저장합니다")
     public ResponseEntity<Void> initializeAllEmbeddings() {
         postEmbeddingManageService.initializeAllPostEmbeddings();
         return ResponseEntity.ok().build();

--- a/src/main/java/kr/co/amateurs/server/domain/event/VerificationEvent.java
+++ b/src/main/java/kr/co/amateurs/server/domain/event/VerificationEvent.java
@@ -5,7 +5,7 @@ import kr.co.amateurs.server.domain.entity.user.User;
 
 public record VerificationEvent(
         Long verifyId,
-        byte[] imageBytes,
+        String imageUrl,
         String filename,
         User user,
         DevCourseTrack devcourseName,

--- a/src/main/java/kr/co/amateurs/server/domain/event/VerificationEvent.java
+++ b/src/main/java/kr/co/amateurs/server/domain/event/VerificationEvent.java
@@ -1,0 +1,14 @@
+package kr.co.amateurs.server.domain.event;
+
+import kr.co.amateurs.server.domain.entity.post.enums.DevCourseTrack;
+import kr.co.amateurs.server.domain.entity.user.User;
+
+public record VerificationEvent(
+        Long verifyId,
+        byte[] imageBytes,
+        String filename,
+        User user,
+        DevCourseTrack devcourseName,
+        String devcourseBatch
+) {
+}

--- a/src/main/java/kr/co/amateurs/server/service/ai/AiPostAnalysis.java
+++ b/src/main/java/kr/co/amateurs/server/service/ai/AiPostAnalysis.java
@@ -57,26 +57,42 @@ public interface AiPostAnalysis {
         선택한 토픽: {{userTopics}}
         
         요구사항:
-        - 선택한 토픽을 기반으로 기본적인 관심사 추론
-        - 해당 프로필은 추후 맞춤 게시글 추천에 활용
-        - 관심 기술 키워드는 선택한 토픽 관련 3-5개로 구성(ex "Java, Spring, 데이터베이스")
-        - 토픽을 바탕으로 사용자의 현재 기술 관심분야를 작성
+        1. interest_keyword: 선택한 토픽과 관련된 핵심 키워드 3-5개를 쉼표로 구분 (예: "백엔드 개발, Spring Boot, API 설계, 데이터베이스")
+    
+        2. persona_description: 선택한 토픽에 관심이 있다는 것을 한 문장으로 자연스럽게 표현 (60-100자)
+            - 예시: "Spring과 자바 개발에 관심이 있고, 백엔드 개발과 서버 아키텍처에 관심이 있는 개발자"
+            - 예시: "react를 활용한 프론트엔드 기술과 사용자 인터페이스 개발을 좋아함"
+            - 예시: "AI/ML 기술과 데이터 분석 분야에 흥미를 느끼고 있음"
+            
+        선택한 토픽을 활용하여 토픽의 내용이 잘 드러날 수 있게 작성.
         """)
     AiProfileResponse generateInitialProfile(@V("userTopics") String userTopics);
 
     @UserMessage("""
-        사용자의 활동 데이터를 분석하여 개인화된 프로필을 생성해주세요.
-        
-        사용자 가입 토픽: {{userTopics}}
-        데브코스 정보: {{devcourseName}}
-        
-        사용자 활동 요약:
-        {{summaries}}
-        
-        요구사항:
-        - 데브코스 정보가 "정보 없음"인 경우 무시하고 다른 정보로 분석
-        - 활동 요약이 부족한 경우 토픽 정보를 더 중점적으로 활용
-        - 관심 기술 키워드는 5~8개 이내로 작성
-        """)
+            사용자의 활동 데이터를 분석하여 개인화된 프로필을 생성해주세요.
+            
+            사용자 가입 토픽: {{userTopics}}
+            데브코스 정보: {{devcourseName}}
+            
+            사용자 활동 요약:
+            {{summaries}}
+            
+                요구사항:
+                1. interest_keyword: 활동 데이터에서 자주 등장하는 기술/키워드를 우선으로 하되, 가입 토픽과 데브코스 정보도 고려하여 5-8개 추출
+                    - 실제 활동에서 나타난 관심사 > 가입 시 선택한 토픽 순으로 우선순위
+                    - 예: "React, TypeScript, AWS, Docker"
+                
+                2. persona_description: 실제 활동 패턴을 반영한 구체적인 설명 (100-150자)
+                   - 어떤 기술 스택을 주로 다루는지
+                   - 어떤 종류의 프로젝트나 주제에 관심이 많은지
+                   - 활동 데이터에서 드러나는 개발 성향이나 특징
+                    - 예: "React와 Node.js로 풀스택 개발을 하며, 팀 프로젝트와 코드 리뷰에 적극적으로 참여하는 개발자"
+                실제 활동 데이터를 최우선으로 반영하여 더 정확하고 개인화된 프로필을 만들어주세요.
+            
+            요구사항:
+            - 데브코스 정보가 "정보 없음"인 경우 무시하고 다른 정보로 분석
+            - 활동 요약이 부족한 경우 토픽 정보를 더 중점적으로 활용
+            - 관심 기술 키워드는 5~8개 이내로 작성
+            """)
     AiProfileResponse generateFinalProfile(@V("userTopics") String userTopics, @V("devcourseName") String devcourseName, @V("summaries") String summaries);
 }

--- a/src/main/java/kr/co/amateurs/server/service/verify/VerifyService.java
+++ b/src/main/java/kr/co/amateurs/server/service/verify/VerifyService.java
@@ -150,6 +150,8 @@ public class VerifyService {
     private PythonServiceResponseDTO.DataDTO callPythonVerificationServiceByUrl(String imageUrl, String filename) {
         String url = verificationServiceUrl + verificationEndpoint;
 
+        log.info("Python 서비스 URL 호출: {}, imageUrl: {}, filename: {}", url, imageUrl, filename);
+
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -126,7 +126,7 @@ cookie:
 verification:
   service:
     url: http://localhost:5000
-    endpoint: /verify
+    endpoint: /verify/url
 
 otel:
   service:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -114,7 +114,7 @@ swagger:
 verification:
   service:
     url: ${VERIFICATION_SERVICE_URL}
-    endpoint: /verify
+    endpoint: /verify/url
 
 otel:
   service:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -135,7 +135,7 @@ cookie:
 verification:
   service:
     url: ${VERIFICATION_SERVICE_URL}
-    endpoint: /verify
+    endpoint: /verify/url
 
 otel:
   service:


### PR DESCRIPTION
## #️⃣연관된 이슈
#225

## 📝작업 내용
수강생 인증 버튼 클릭시 플라스크 서버로 넘어가지 않는 이슈 및
```
kr.co.amateurs.server.exception.CustomException: 조회할 대상을 찾을 수 없습니다.
	at kr.co.amateurs.server.service.verify.VerifyService.processVerificationAsync(VerifyService.java:92)
```

- 트랜잭션이 커밋되기 전에 비동기 스레드가 실행되어, DB에 데이터 반영이 안되는 현상으로 추측
- 이벤트 발행으로 재처리
- 프로필 생성 관련 프롬프트 구체화

## 💬리뷰 요구사항(선택) 및 기타 참고사항
- 트랜잭션 처리가 잘 되었는지 확인 부탁드립니다
- 현재 로컬 및 스웨거에서는 잘 작동이 되어 배포 후 작동 확인해보겠습니다

## ✅ 체크리스트

- [ ] 코드 점검 완료했습니다
- [ ] 문서/주석 최신화 완료했습니다
