### PR TITLE
Test: PasswordReset 기능 테스트 코드 완성 #260

### DIFF
--- a/src/test/java/kr/co/amateurs/server/config/TestEmailService.java
+++ b/src/test/java/kr/co/amateurs/server/config/TestEmailService.java
@@ -1,0 +1,46 @@
+package kr.co.amateurs.server.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import kr.co.amateurs.server.service.auth.EmailService;
+
+/**
+ * 테스트 환경에서 사용하는 EmailService
+ * 실제 메일을 전송하지 않고 로그만 출력합니다.
+ */
+@Service
+@Profile("test")
+@Primary
+@Slf4j
+public class TestEmailService extends EmailService {
+
+    public TestEmailService() {
+        super(null);
+    }
+
+    @Override
+    public void sendPasswordResetEmail(String to, String resetToken) {
+        // 테스트에서는 실제로 메일을 보내지 않고 로그만 출력
+        log.info("🧪 TEST: 비밀번호 재설정 이메일 전송 시뮬레이션");
+        log.info("   - 수신자: {}", maskEmail(to));
+        log.info("   - 토큰: {}", resetToken);
+        log.info("   - 상태: 전송 완료 (시뮬레이션)");
+    }
+
+    private String maskEmail(String email) {
+        if (email == null || !email.contains("@")) {
+            return "***";
+        }
+        String[] parts = email.split("@");
+        String localPart = parts[0];
+        String domain = parts[1];
+
+        if (localPart.length() <= 3) {
+            return localPart.charAt(0) + "***@" + domain;
+        } else {
+            return localPart.substring(0, 3) + "***@" + domain;
+        }
+    }
+}

--- a/src/test/java/kr/co/amateurs/server/controller/auth/AuthControllerTest.java
+++ b/src/test/java/kr/co/amateurs/server/controller/auth/AuthControllerTest.java
@@ -601,4 +601,64 @@ public class AuthControllerTest extends AbstractControllerTest {
                 .statusCode(404)
                 .body("message", equalTo("존재하지 않는 사용자입니다."));
     }
+
+    @Test
+    void 유효한_토큰과_일치하는_비밀번호로_재설정하면_성공한다() {
+        // Given
+        SignupRequestDTO signupRequest = UserTestFixture.createUniqueSignupRequest();
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(signupRequest)
+                .when()
+                .post("/auth/signup")
+                .then()
+                .statusCode(201);
+
+        PasswordResetRequestDTO resetRequest = new PasswordResetRequestDTO(signupRequest.email());
+        String resetToken = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(resetRequest)
+                .when()
+                .post("/auth/password/reset/request")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("resetToken");
+
+        PasswordResetConfirmDTO confirmRequest = new PasswordResetConfirmDTO(
+                resetToken,
+                "newPassword123",
+                "newPassword123"
+        );
+
+        // When & Then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(confirmRequest)
+                .when()
+                .post("/auth/password/reset/confirm")
+                .then()
+                .statusCode(200)
+                .body("message", equalTo("비밀번호가 성공적으로 변경되었습니다"));
+    }
+
+    @Test
+    void 유효하지_않은_토큰으로_비밀번호_재설정_확인하면_400_에러가_발생한다() {
+        // Given
+        PasswordResetConfirmDTO request = new PasswordResetConfirmDTO(
+                "invalid-token",
+                "newPassword123",
+                "newPassword123"
+        );
+
+        // When & Then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/auth/password/reset/confirm")
+                .then()
+                .statusCode(400)
+                .body("message", equalTo("유효하지 않은 재설정 토큰입니다."));
+    }
 }

--- a/src/test/java/kr/co/amateurs/server/fixture/common/UserTestFixture.java
+++ b/src/test/java/kr/co/amateurs/server/fixture/common/UserTestFixture.java
@@ -93,4 +93,41 @@ public class UserTestFixture {
                 .nickname(generateUniqueNickname())
                 .build();
     }
+
+    /**
+     * 로컬 사용자를 생성합니다
+     */
+    public static User createLocalUser(String email, String nickname, String encodedPassword) {
+        User user = User.builder()
+                .email(email)
+                .nickname(nickname)
+                .name("테스트사용자")
+                .password(encodedPassword)
+                .role(Role.GUEST)
+                .providerType(ProviderType.LOCAL)
+                .isProfileCompleted(true)
+                .build();
+
+        user.addUserTopics(Set.of(Topic.FRONTEND, Topic.BACKEND));
+        return user;
+    }
+
+    /**
+     * OAuth 사용자를 생성합니다
+     */
+    public static User createOAuthUser(String email, String nickname, ProviderType providerType, String providerId) {
+        User user = User.builder()
+                .email(email)
+                .nickname(nickname)
+                .name("OAuth사용자")
+                .password(null)
+                .role(Role.GUEST)
+                .providerType(providerType)
+                .providerId(providerId)
+                .isProfileCompleted(true)
+                .build();
+
+        user.addUserTopics(Set.of(Topic.FRONTEND, Topic.BACKEND));
+        return user;
+    }
 }

--- a/src/test/java/kr/co/amateurs/server/service/auth/PasswordResetServiceTest.java
+++ b/src/test/java/kr/co/amateurs/server/service/auth/PasswordResetServiceTest.java
@@ -148,6 +148,31 @@ public class PasswordResetServiceTest {
         assertThat(passwordResetTokenRepository.findByToken("expired-token")).isEmpty();
     }
 
+    @Test
+    void 유효한_토큰과_일치하는_비밀번호로_재설정하면_성공한다() {
+        // Given
+        User user = createAndSaveLocalUser("user@test.com", "nickname", "oldPassword123");
+        String originalPassword = user.getPassword();
+
+        PasswordResetToken token = createAndSavePasswordResetToken("valid-token", "user@test.com");
+        PasswordResetConfirmDTO request = new PasswordResetConfirmDTO(
+                "valid-token",
+                "newPassword123",
+                "newPassword123"
+        );
+
+        // When
+        PasswordResetConfirmResponseDTO response = passwordResetService.confirmPasswordReset(request);
+
+        // Then
+        assertThat(response.message()).isEqualTo("비밀번호가 성공적으로 변경되었습니다");
+
+        User updatedUser = userRepository.findByEmail("user@test.com").orElseThrow();
+        assertThat(updatedUser.getPassword()).isNotEqualTo(originalPassword);
+        assertThat(passwordEncoder.matches("newPassword123", updatedUser.getPassword())).isTrue();
+        assertThat(passwordResetTokenRepository.findByToken("valid-token")).isEmpty();
+    }
+
 
 
 

--- a/src/test/java/kr/co/amateurs/server/service/auth/PasswordResetServiceTest.java
+++ b/src/test/java/kr/co/amateurs/server/service/auth/PasswordResetServiceTest.java
@@ -12,6 +12,7 @@ import kr.co.amateurs.server.domain.entity.user.enums.ProviderType;
 import kr.co.amateurs.server.domain.entity.user.enums.Role;
 import kr.co.amateurs.server.domain.entity.user.enums.Topic;
 import kr.co.amateurs.server.exception.CustomException;
+import kr.co.amateurs.server.fixture.common.UserTestFixture;
 import kr.co.amateurs.server.repository.auth.PasswordResetTokenRepository;
 import kr.co.amateurs.server.repository.user.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -180,38 +181,14 @@ public class PasswordResetServiceTest {
 
     // 헬퍼 메서드들
     private User createAndSaveLocalUser(String email, String nickname, String password) {
-        User user = User.builder()
-                .email(email)
-                .nickname(nickname)
-                .name("테스트사용자")
-                .password(passwordEncoder.encode(password))
-                .role(Role.GUEST)
-                .providerType(ProviderType.LOCAL)
-                .isProfileCompleted(true)
-                .build();
-
-        user.addUserTopics(Set.of(Topic.FRONTEND, Topic.BACKEND));
-
+        User user = UserTestFixture.createLocalUser(email, nickname, passwordEncoder.encode(password));
         return userRepository.save(user);
     }
 
     private User createAndSaveGitHubUser(String email, String nickname) {
-        User user = User.builder()
-                .email(email)
-                .nickname(nickname)
-                .name("GitHub사용자")
-                .password(null)
-                .role(Role.GUEST)
-                .providerType(ProviderType.GITHUB)
-                .providerId("github123")
-                .isProfileCompleted(true)
-                .build();
-
-        user.addUserTopics(Set.of(Topic.FRONTEND, Topic.BACKEND));
-
+        User user = UserTestFixture.createOAuthUser(email, nickname, ProviderType.GITHUB, "github123");
         return userRepository.save(user);
     }
-
 
     private PasswordResetToken createAndSavePasswordResetToken(String token, String email) {
         PasswordResetToken resetToken = PasswordResetToken.builder()

--- a/src/test/java/kr/co/amateurs/server/service/auth/PasswordResetServiceTest.java
+++ b/src/test/java/kr/co/amateurs/server/service/auth/PasswordResetServiceTest.java
@@ -1,0 +1,124 @@
+package kr.co.amateurs.server.service.auth;
+
+import kr.co.amateurs.server.config.EmbeddedRedisConfig;
+import kr.co.amateurs.server.domain.dto.auth.PasswordResetRequestDTO;
+import kr.co.amateurs.server.domain.dto.auth.PasswordResetResponseDTO;
+import kr.co.amateurs.server.domain.entity.auth.PasswordResetToken;
+import kr.co.amateurs.server.domain.entity.user.User;
+import kr.co.amateurs.server.domain.entity.user.enums.ProviderType;
+import kr.co.amateurs.server.domain.entity.user.enums.Role;
+import kr.co.amateurs.server.domain.entity.user.enums.Topic;
+import kr.co.amateurs.server.repository.auth.PasswordResetTokenRepository;
+import kr.co.amateurs.server.repository.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@Import(EmbeddedRedisConfig.class)
+public class PasswordResetServiceTest {
+
+    @Autowired
+    private PasswordResetService passwordResetService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordResetTokenRepository passwordResetTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+
+    @Test
+    void 유효한_로컬_사용자_이메일로_비밀번호_재설정_요청하면_성공한다() {
+        // Given
+        User user = createAndSaveLocalUser("user@test.com", "nickname", "password123");
+        PasswordResetRequestDTO request = new PasswordResetRequestDTO("user@test.com");
+
+        // When
+        PasswordResetResponseDTO response = passwordResetService.requestPasswordReset(request);
+
+        // Then
+        assertThat(response.message()).isEqualTo("비밀번호 재설정 정보가 확인되었습니다. 새로운 비밀번호를 설정해주세요.");
+        assertThat(response.resetToken()).isNotNull();
+        assertThat(response.resetToken()).isNotBlank();
+    }
+
+
+
+
+
+    // 헬퍼 메서드들
+    private User createAndSaveLocalUser(String email, String nickname, String password) {
+        User user = User.builder()
+                .email(email)
+                .nickname(nickname)
+                .name("테스트사용자")
+                .password(passwordEncoder.encode(password))
+                .role(Role.GUEST)
+                .providerType(ProviderType.LOCAL)
+                .isProfileCompleted(true)
+                .build();
+
+        user.addUserTopics(Set.of(Topic.FRONTEND, Topic.BACKEND));
+
+        return userRepository.save(user);
+    }
+
+    private User createAndSaveGitHubUser(String email, String nickname) {
+        User user = User.builder()
+                .email(email)
+                .nickname(nickname)
+                .name("GitHub사용자")
+                .password(null)
+                .role(Role.GUEST)
+                .providerType(ProviderType.GITHUB)
+                .providerId("github123")
+                .isProfileCompleted(true)
+                .build();
+
+        user.addUserTopics(Set.of(Topic.FRONTEND, Topic.BACKEND));
+
+        return userRepository.save(user);
+    }
+
+
+    private PasswordResetToken createAndSavePasswordResetToken(String token, String email) {
+        PasswordResetToken resetToken = PasswordResetToken.builder()
+                .token(token)
+                .email(email)
+                .build();
+        return passwordResetTokenRepository.save(resetToken);
+    }
+
+    private PasswordResetToken createAndSaveExpiredPasswordResetToken(String token, String email) {
+        PasswordResetToken resetToken = PasswordResetToken.builder()
+                .token(token)
+                .email(email)
+                .build();
+
+        try {
+            java.lang.reflect.Field expiresAtField = PasswordResetToken.class.getDeclaredField("expiresAt");
+            expiresAtField.setAccessible(true);
+            expiresAtField.set(resetToken, LocalDateTime.now().minusHours(1));
+        } catch (Exception e) {
+            throw new RuntimeException("테스트 데이터 설정 실패", e);
+        }
+
+        return passwordResetTokenRepository.save(resetToken);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#260 

## 📝작업 내용

PasswordReset 기능의 테스트 코드를 작성했습니다

- **PasswordResetServiceTest**
  - 비밀번호 재설정 요청 성공/실패 케이스
  - 비밀번호 재설정 확인 성공/실패 케이스 
- **AuthControllerTest** 
  - 비밀번호 재설정 요청 API 테스트
  - 비밀번호 재설정 확인 API 테스트


## 💬리뷰 요구사항(선택) 및 기타 참고사항


## ✅ 체크리스트

- [ ] 코드 점검 완료했습니다
- [ ] 문서/주석 최신화 완료했습니다
