### PR TITLE
Chore: S3를 R2로 변경

### DIFF
--- a/src/main/java/kr/co/amateurs/server/config/S3Config.java
+++ b/src/main/java/kr/co/amateurs/server/config/S3Config.java
@@ -8,25 +8,32 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+import java.net.URI;
 
 @Configuration
 public class S3Config {
 
-    @Value("${cloud.aws.credentials.access-key}")
+    @Value("${cloudflare.r2.endpoint}")
+    private String endpoint;
+
+    @Value("${cloudflare.r2.access-key}")
     private String accessKey;
 
-    @Value("${cloud.aws.credentials.secret-key}")
+    @Value("${cloudflare.r2.secret-key}")
     private String secretKey;
-
-    @Value("${cloud.aws.region.static}")
-    private String region;
 
     @Bean
     public S3Client s3Client() {
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
         return S3Client.builder()
-                .region(Region.of(region))
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.of("auto"))
                 .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
                 .build();
     }
 }

--- a/src/main/java/kr/co/amateurs/server/service/file/FileService.java
+++ b/src/main/java/kr/co/amateurs/server/service/file/FileService.java
@@ -36,10 +36,10 @@ import java.util.regex.Pattern;
 @RequiredArgsConstructor
 public class FileService {
 
-    @Value("${cloud.aws.cloudfront.domain}")
+    @Value("${cloudflare.r2.public-url}")
     public String publicUrl;
 
-    @Value("${cloud.aws.s3.bucket}")
+    @Value("${cloudflare.r2.bucket}")
     private String bucket;
 
     private final S3Client s3Client;

--- a/src/main/java/kr/co/amateurs/server/service/file/UnreferencedImageClearScheduler.java
+++ b/src/main/java/kr/co/amateurs/server/service/file/UnreferencedImageClearScheduler.java
@@ -23,10 +23,10 @@ public class UnreferencedImageClearScheduler {
     private final PostImageRepository postImageRepository;
     private final FileService fileService;
 
-    @Value("${cloud.aws.cloudfront.domain}")
+    @Value("${cloudflare.r2.public-url}")
     public String publicUrl;
 
-    @Value("${cloud.aws.s3.bucket}")
+    @Value("${cloudflare.r2.bucket}")
     private String bucket;
 
     // 한번에 처리할 작업의 크기(메모리 오버 대비)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -88,18 +88,6 @@ jwt:
   access-token-expiration-ms: 3600000
   refresh-token-expiration-ms: 1209600000
 
-cloud:
-  aws:
-    credentials:
-      access-key: ${AWS_ACCESS_KEY}
-      secret_key: ${AWS_SECRET_KEY}
-    region:
-      static: ${S3_REGION}
-    s3:
-      bucket: ${S3_BUCKET_NAME}
-    cloudfront:
-      domain: ${CLOUD_FRONT_DOMAIN_NAME}
-
 management:
   endpoints:
     web:
@@ -136,3 +124,11 @@ otel:
     exporter: none
   logs:
     exporter: none
+
+cloudflare:
+  r2:
+    endpoint: ${CLOUDFLARE_R2_ENDPOINT}
+    access-key: ${CLOUDFLARE_R2_ACCESS_KEY}
+    secret-key: ${CLOUDFLARE_R2_SECRET_KEY}
+    bucket: ${CLOUDFLARE_R2_BUCKET}
+    public-url: ${CLOUDFLARE_R2_PUBLIC_URL}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -103,18 +103,6 @@ jwt:
   access-token-expiration-ms: 3600000
   refresh-token-expiration-ms: 1209600000
 
-cloud:
-  aws:
-    credentials:
-      access-key: ${AWS_ACCESS_KEY}
-      secret_key: ${AWS_SECRET_KEY}
-    region:
-      static: ${S3_REGION}
-    s3:
-      bucket: ${S3_BUCKET_NAME}
-    cloudfront:
-      domain: ${CLOUD_FRONT_DOMAIN_NAME}
-
 oauth:
   success-redirect-url: http://localhost:5173
 
@@ -139,3 +127,11 @@ otel:
     exporter: none
   logs:
     exporter: none
+
+cloudflare:
+  r2:
+    endpoint: https://c50a1c33eadf7272948ce35cde67aed2.r2.cloudflarestorage.com
+    access-key: 0001a766c37a2d744a461c00b400aaad
+    secret-key: 7360ce98ca8a8f78f9543ff287ead34644f5b95d8b779e6f7a2f0e7db1fa3f08
+    bucket: amateurs-bucket
+    public-url: pub-73aa20f9c02b434b9385f7c7b1437b0b.r2.dev

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -112,18 +112,6 @@ jwt:
   access-token-expiration-ms: 3600000
   refresh-token-expiration-ms: 1209600000
 
-cloud:
-  aws:
-    credentials:
-      access-key: ${AWS_ACCESS_KEY}
-      secret_key: ${AWS_SECRET_KEY}
-    region:
-      static: ${S3_REGION}
-    s3:
-      bucket: ${S3_BUCKET_NAME}
-    cloudfront:
-      domain: ${CLOUD_FRONT_DOMAIN_NAME}
-
 management:
   endpoints:
     web:
@@ -173,3 +161,11 @@ otel:
       endpoint: ${OTEL_COLLECTOR_URL}
       compression: gzip
       timeout: 10s
+
+cloudflare:
+  r2:
+    endpoint: ${CLOUDFLARE_R2_ENDPOINT}
+    access-key: ${CLOUDFLARE_R2_ACCESS_KEY}
+    secret-key: ${CLOUDFLARE_R2_SECRET_KEY}
+    bucket: ${CLOUDFLARE_R2_BUCKET}
+    public-url: ${CLOUDFLARE_R2_PUBLIC_URL}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호 (작성 시 지우기)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) - (작성 시 지우기)

AWS S3 스토리지를 CloudFlare R2 무료 스토리지로 인프라 변경

## 💬리뷰 요구사항(선택) 및 기타 참고사항

> ex) 실행 시 yml 파일 필요합니다. (작성 시 지우기)

환경변수 확인 잘 해야 합니다. 기존 AWS cloud 관련 환경변수는 지우고 새로 올린 Cloudflare R2 환경변수로 넣어줘야 합니다.
yml 파일 다 수정했고 따로 gitignore되어 있는게 환경변수 파일밖에 없어서 환경변수만 신경잘 쓰면 될 것 같아요.

이미지 올라가는건 테스트해서 잘 올라가는거 확인했습니다.
<img width="1185" height="516" alt="image" src="https://github.com/user-attachments/assets/299914a8-0f41-4796-b85d-db79df9ed82e" />


## ✅ 체크리스트

- [ ] 코드 점검 완료했습니다
- [ ] 문서/주석 최신화 완료했습니다
